### PR TITLE
Issue #2 minimal ci

### DIFF
--- a/.github/workflows/Check_Compose.yaml
+++ b/.github/workflows/Check_Compose.yaml
@@ -11,8 +11,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Check that the image builds and runs
         run: docker compose up -d
-      - name: Sleep for 30 seconds
-        run: sleep 30s
+      - name: Sleep for 120 seconds
+        run: sleep 120s
         shell: bash
       - name: Shut docker down
         run: docker compose down

--- a/.github/workflows/Check_Compose.yaml
+++ b/.github/workflows/Check_Compose.yaml
@@ -10,6 +10,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Check that the image builds and runs
-        run: docker compose up -t 60
+        run: docker compose up -d
+      - name: Sleep for 120 seconds
+        run: sleep 120s
+        shell: bash
       - name: Shut docker down
         run: docker compose down

--- a/.github/workflows/Check_Compose.yaml
+++ b/.github/workflows/Check_Compose.yaml
@@ -10,4 +10,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Check that the image builds
-        run: docker build . --file Dockerfile
+        run: docker build . --file agent/distribution/base/Dockerfile

--- a/.github/workflows/Check_Compose.yaml
+++ b/.github/workflows/Check_Compose.yaml
@@ -10,4 +10,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Check that the image builds
-        run: docker compose up
+        run: docker compose

--- a/.github/workflows/Check_Compose.yaml
+++ b/.github/workflows/Check_Compose.yaml
@@ -9,5 +9,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Check that the image builds
+      - name: Check that the image builds and runs
         run: docker compose up -d
+      - name: Sleep for 30 seconds
+        run: sleep 30s
+        shell: bash
+      - name: Shut docker down
+        run: docker compose down

--- a/.github/workflows/Check_Compose.yaml
+++ b/.github/workflows/Check_Compose.yaml
@@ -10,4 +10,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Check that the image builds
-        run: docker build . --file agent/distribution/base/Dockerfile
+        run: docker compose up

--- a/.github/workflows/Check_Compose.yaml
+++ b/.github/workflows/Check_Compose.yaml
@@ -10,4 +10,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Check that the image builds
-        run: docker compose create
+        run: docker compose up -d

--- a/.github/workflows/Check_Compose.yaml
+++ b/.github/workflows/Check_Compose.yaml
@@ -10,9 +10,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Check that the image builds and runs
-        run: docker compose up -d
-      - name: Sleep for 120 seconds
-        run: sleep 120s
-        shell: bash
+        run: docker compose up -t 60
       - name: Shut docker down
         run: docker compose down

--- a/.github/workflows/Check_Compose.yaml
+++ b/.github/workflows/Check_Compose.yaml
@@ -1,0 +1,13 @@
+---
+name: Check Docker Can Compose
+
+on: push
+
+jobs:
+  Check_Compose:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check that the image builds
+        run: docker build . --file Dockerfile

--- a/.github/workflows/Check_Compose.yaml
+++ b/.github/workflows/Check_Compose.yaml
@@ -11,8 +11,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Check that the image builds and runs
         run: docker compose up -d
-      - name: Sleep for 120 seconds
-        run: sleep 120s
+      - name: Sleep for 30 seconds
+        run: sleep 30s
         shell: bash
       - name: Shut docker down
         run: docker compose down

--- a/.github/workflows/Check_Compose.yaml
+++ b/.github/workflows/Check_Compose.yaml
@@ -10,4 +10,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Check that the image builds
-        run: docker compose
+        run: docker compose create

--- a/agent/distribution/base/Dockerfile
+++ b/agent/distribution/base/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:slim-bookworm
 #  Copy requirements file into the /src repository
-COPY agent/requirements.txt /src/requirements.txt
+COPY requirements.txt /src/requirements.txt
 RUN   pip install --upgrade pip && pip install --no-cache-dir  -r /src/requirements.txt
 # Run the agent
 ENTRYPOINT ["rfswarm-agent", "-m", "http://manager:8138", "-g", "3"]

--- a/agent/distribution/base/Dockerfile
+++ b/agent/distribution/base/Dockerfile
@@ -3,9 +3,9 @@ ENV     PYTHONPATH="${PYTHONPATH}:/src/:/usr/local/bin"
 ENV     PATH="${PATH}:~/usr/local/bin:/src"
 # Add python dependency
 RUN     apt-get -y update && apt-get install -y apt-utils bc curl wget libaio1 unzip gcc netcat-traditional bash build-essential \
-python3-pip python3-pip python-dev-is-python3 python3-pil 
-#  Copy requirements file in the /src repository
-COPY requirements.txt /src/requirements.txt
+python3-pip python3-pip python-dev-is-python3 python3-pil
+#  Copy requirements file into the /src repository
+COPY agent/requirements.txt /src/requirements.txt
 RUN   pip install --upgrade pip && pip install --no-cache-dir  -r /src/requirements.txt
-# Run the agent 
+# Run the agent
 ENTRYPOINT ["rfswarm-agent", "-m", "http://manager:8138", "-g", "3"]


### PR DESCRIPTION
Here's a minimal CI test build of the docker file. (Issue #2)

I needed to change the dockerfile to include the path to the requirements.txt file to get it to build so be aware of that before you merge this change

Feel free to rename the workflow file or it's name etc, I intended this to be a starting point for you to show you how to trigger GitHub's CI, from here you can tune it as you need.

It might be better to not use a requirements.txt file, but rather just put the pip command with the required packages directly in the docker file, then you only have the 1 file to manage, but I'll leave that decision to you

Dave.