### PR TITLE
fix: copy only entrypoint.sh file

### DIFF
--- a/agent/base/Dockerfile
+++ b/agent/base/Dockerfile
@@ -17,7 +17,7 @@ RUN useradd -m rfagent
 # Switch to 'rfagent user'
 USER rfagent
 
-COPY --chown=rfagent --chmod=765 agent/base /usr/rfagent
+COPY --chown=rfagent --chmod=765 agent/base/entrypoint.sh /usr/rfagent/entrypoint.sh
 
 WORKDIR  /usr/rfagent
 

--- a/agent/seleniumlibrary-firefox/Dockerfile
+++ b/agent/seleniumlibrary-firefox/Dockerfile
@@ -67,6 +67,6 @@ RUN firefox --version
 #==============================================================
 # Run entrypoint_firefox.sh to set virtual display
 #==============================================================
-COPY --chown=rfagent --chmod=765  agent/seleniumlibrary-firefox  /usr/rfagent
+COPY --chown=rfagent --chmod=765  agent/seleniumlibrary-firefox/entrypoint.sh /usr/rfagent/entrypoint.sh
 WORKDIR  /usr/rfagent
 ENTRYPOINT [ "/usr/rfagent/entrypoint.sh" ]


### PR DESCRIPTION
@Maresther-B, I created a new ticket for a small fix related to our latest changes. In the copy step, you copied the entire folder into docker image (including the Dockerfile). It’s better to copy only the specific file if possible.
